### PR TITLE
Samples/fulldemo: Move enum into separate header.

### DIFF
--- a/Software/Snippets/fulldemo/defs.h
+++ b/Software/Snippets/fulldemo/defs.h
@@ -1,0 +1,25 @@
+#ifndef _DEFS_H_
+#define _DEFS_H_
+
+typedef enum _LCDtest {
+    FINGERPAINT = 0,
+    JOYABS = 1,
+    JOYREL = 2,
+    ACCELPAINT = 3,
+    ROUNDREC = 8,
+    ROUNDRECFILL = 9,                                                           
+    TEXT = 10, 
+    FILL = 11, 
+    LINES = 12, 
+    HORIZVERT = 13, 
+    RECT = 14, 
+    RECTFILL = 15, 
+    CIRCLE = 16, 
+    CIRCFILL = 17, 
+    TRIANGLE = 18, 
+    TRIFILL = 19
+} LCDtest;
+
+void lcd_test(LCDtest choice);
+
+#endif

--- a/Software/Snippets/fulldemo/fulldemo.ino
+++ b/Software/Snippets/fulldemo/fulldemo.ino
@@ -13,6 +13,7 @@
   MIT license, all text above must be included in any redistribution
  ****************************************************/
 
+
 /*
 I2C addresses:
 Audio:  0x1A
@@ -25,6 +26,31 @@ BME230: 0x77 (Temp/Humidity/Pressure)
 */
 
 #define CONFIG_DISABLE_HAL_LOCKS 1
+
+#include <Wire.h>
+#include <SPI.h>
+
+#include "Adafruit_GFX.h"
+// Support for LCD screen
+// The latest version of that library may not be up to date and miss a patch for ESP32
+// which will cause a compilation error:
+// Adafruit_ILI9341.cpp:113:3: error: 'mosiport' was not declared in this scope
+// If so, get the latest version from github, or just patch this single line
+// https://github.com/adafruit/Adafruit_ILI9341/blob/master/Adafruit_ILI9341.cpp#L98
+#include "Adafruit_ILI9341.h"
+
+// Support for APA106 RGB LEDs
+// Current Adafruit code does not support writing to any LED strip on ESP32
+#include "Adafruit_NeoPixel.h"
+
+// Accelerometer
+#include <Adafruit_Sensor.h>
+#include <Adafruit_ADXL345_U.h>
+
+#include "defs.h"
+
+// Touch screen
+#include "XPT2046_Touchscreen.h"
 
 
 // https://github.com/CCHS-Melbourne/iotuz-esp32-hardware/wiki has hardware mapping details
@@ -62,24 +88,6 @@ uint16_t joyValueX;
 uint16_t joyValueY;
 bool joyBtnValue;
 
-#include "SPI.h"
-#include "Adafruit_GFX.h"
-// Support for LCD screen
-// The latest version of that library may not be up to date and miss a patch for ESP32
-// which will cause a compilation error:
-// Adafruit_ILI9341.cpp:113:3: error: 'mosiport' was not declared in this scope
-// If so, get the latest version from github, or just patch this single line
-// https://github.com/adafruit/Adafruit_ILI9341/blob/master/Adafruit_ILI9341.cpp#L98
-#include "Adafruit_ILI9341.h"
-#include <Wire.h>
-
-// Support for APA106 RGB LEDs
-// Current Adafruit code does not support writing to any LED strip on ESP32
-#include "Adafruit_NeoPixel.h"
-
-// Accelerometer
-#include <Adafruit_Sensor.h>
-#include <Adafruit_ADXL345_U.h>
 Adafruit_ADXL345_Unified accel = Adafruit_ADXL345_Unified(12345);
 
 // TFT + Touch Screen Setup Start
@@ -98,8 +106,6 @@ Adafruit_ILI9341 tft = Adafruit_ILI9341(TFT_CS, TFT_DC, TFT_RST);
 char tft_str[41];
 // TFT Setup End
 
-// Touch screen
-#include "XPT2046_Touchscreen.h"
 // Touch screen select is on port expander line 6, not directly connected, so the library
 // cannot toggle it directly. It however requires a CS pin, so I'm giving it 33, a spare IO
 // pin so that it doesn't break anything else.
@@ -141,26 +147,6 @@ char* opt_name[NVERT][NHORIZ][3] = {
 uint16_t tftw, tfth;
 // number of pixels of each selection box (height and width)
 uint16_t boxw, boxh;
-
-typedef enum {
-    FINGERPAINT = 0,
-    JOYABS = 1,
-    JOYREL = 2,
-    ACCELPAINT = 3,
-    ROUNDREC = 8,
-    ROUNDRECFILL = 9,
-    TEXT = 10,
-    FILL = 11,
-    LINES = 12,
-    HORIZVERT = 13,
-    RECT = 14,
-    RECTFILL = 15,
-    CIRCLE = 16,
-    CIRCFILL = 17,
-    TRIANGLE = 18,
-    TRIFILL = 19,
-} LCDtest;
-
 
 unsigned long testFillScreen() {
   unsigned long start = micros();


### PR DESCRIPTION
The arduino environment seems to get easily confused if
enums and structs are defined in the main sketch and wants
them to be in headers it can parse. Something about it
rearranging the sketch to put all includes first. Without
this change I get compile errors with Arduino 1.6.4 like:

fulldemo:73: error: variable or field 'lcd_test' declared void
fulldemo:73: error: 'LCDtest' was not declared in this scope
fulldemo:75: error: 'TS_Point' does not name a type
variable or field 'lcd_test' declared void